### PR TITLE
Use git url in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript": "~3.5.3"
   },
   "dependencies": {
-    "ds2-tfjs": "file:../ds2-tfjs",
+    "ds2-tfjs": "git+https://github.com/yhwang/ds2-tfjs.git#a1b3b2904b17de2b9bd5010d5adc6fff53fa3ac7",
     "node-wav": "0.0.2"
   }
 }


### PR DESCRIPTION
Instead of using submodule, it's easier to use git url until the
dependencies are published to npm repo.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>